### PR TITLE
Correct highlighting for heredoc string and func definitions

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -45,16 +45,13 @@
 (call (identifier) @keyword
       [(qualified_call
         name: (identifier) @function)
+       (identifier) @function
        (binary_op
         left:
         [(qualified_call
           name: (identifier) @function)
          (identifier) @function]
         operator: "when")]
-      (#match? @keyword "^(defp|def|defmacro|defguard|defdelegate)$"))
-
-(call (identifier) @keyword
-      (identifier) @function
       (#match? @keyword "^(defp|def|defmacro|defguard|defdelegate)$"))
 
 (anonymous_function

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -22,7 +22,6 @@
           (_ !function !object !name (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter)))
           (_ !function !object !name (_ !function !object !name (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter))))
           (_ !function !object !name (_ !function !object !name (_ !function !object !name (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter)))))]))
-       (identifier) @function
        (binary_op
         left:
         [(qualified_call
@@ -40,6 +39,22 @@
         left: (identifier) @variable.parameter
         operator: _ @function
         right: (identifier) @variable.parameter)]
+      (#match? @keyword "^(defp|def|defmacro|defguard|defdelegate)$")
+      (#match? @variable.parameter "^[^_]"))
+
+(call (identifier) @keyword
+      [(qualified_call
+        name: (identifier) @function)
+       (binary_op
+        left:
+        [(qualified_call
+          name: (identifier) @function)
+         (identifier) @function]
+        operator: "when")]
+      (#match? @keyword "^(defp|def|defmacro|defguard|defdelegate)$"))
+
+(call (identifier) @keyword
+      (identifier) @function
       (#match? @keyword "^(defp|def|defmacro|defguard|defdelegate)$"))
 
 (anonymous_function
@@ -75,6 +90,11 @@
 
 (binary_op
  operator: _ @operator)
+
+(heredoc
+ [(heredoc_start)
+  (heredoc_content)
+  (heredoc_end)] @string)
 
 (string_start) @string
 (string_content) @string

--- a/test/highlight/sandbox.ex
+++ b/test/highlight/sandbox.ex
@@ -26,6 +26,16 @@ atom"
 "Multiline
    string"
 
+# Heredoc String
+"""
+Hello world
+"""
+
+"""
+Hello #{["Random" | "String"] && true}
+More Text "with quotes"
+"""
+
 # Char lists
 'this is a list'
 'escapes \' \t \\\''
@@ -135,6 +145,10 @@ defmodule Long.Module.Name do
 
   # Function
   def f(x), do: x
+  def f, do: nil
+  def f(10), do: nil
+  def f(:ok), do: nil
+
   # Operator definition (don't highlight the `x`!)
   def x + y, do: nil
   def x * y, do: nil


### PR DESCRIPTION
**Changes**
* highlighting for heredoc strings
* highlighting for function definition without any argument
* highlighting for function definition without identifier argument (see sandbox.ex)

Added back `(#match? @variable.parameter "^[^_]")`

As of now there is some query duplication, Don't know how to write it more concisely.