### PR TITLE
Unify call expression

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -226,12 +226,7 @@ module.exports = grammar({
         choice(
           seq(
             field("name", choice($.identifier, $.dot_call, $._qualified_call)),
-            seq(
-              choice(
-                alias($.bare_arguments, $.arguments),
-                $.arguments
-              )
-            ),
+            choice($._bare_arguments, $.arguments),
             optional(choice(seq($._terminator, $.do_block), $.do_block))
           ),
           seq(

--- a/grammar.js
+++ b/grammar.js
@@ -176,7 +176,7 @@ module.exports = grammar({
         $.unary_op,
         alias($._capture_op, $.unary_op),
         $.block,
-        $.qualified_call,
+        $._qualified_call,
         $.call,
         $.dot_call,
         $.access_call,
@@ -216,6 +216,8 @@ module.exports = grammar({
         ")"
       ),
 
+    _qualified_call: $ => alias($.qualified_call, $.call),
+
     qualified_call: $ => seq(field("name", $.identifier), $.arguments),
 
     call: $ =>
@@ -223,12 +225,17 @@ module.exports = grammar({
         PREC.CALL,
         choice(
           seq(
-            field("name", choice($.identifier, $.dot_call, $.qualified_call)),
-            choice($._bare_arguments, $.arguments),
+            field("name", choice($.identifier, $.dot_call, $._qualified_call)),
+            seq(
+              choice(
+                alias($.bare_arguments, $.arguments),
+                $.arguments
+              )
+            ),
             optional(choice(seq($._terminator, $.do_block), $.do_block))
           ),
           seq(
-            field("name", choice($.identifier, $.dot_call, $.qualified_call)),
+            field("name", choice($.identifier, $.dot_call, $._qualified_call)),
             $.do_block
           )
         )
@@ -368,7 +375,7 @@ module.exports = grammar({
               $.identifier,
               $.atom,
               alias($._simple_dot_call, $.dot_call),
-              $.qualified_call,
+              $._qualified_call,
               alias($._capture_op, $.unary_op),
               $.integer
             )
@@ -478,7 +485,7 @@ module.exports = grammar({
           $.identifier,
           $.atom,
           alias($._simple_dot_call, $.dot_call),
-          $.qualified_call,
+          $._qualified_call,
           seq("^", $.identifier)
         ),
         "{",

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -25,47 +25,45 @@
       (#match? @keyword "^(defmodule|defexception|defp|def|with|case|cond|raise|import|require|use|defmacrop|defmacro|defguardp|defguard|defdelegate|defstruct|alias|defimpl|defprotocol|defoverridable|receive|if|for|try|throw|unless|reraise|super|quote|unquote|unquote_splicing)$"))
 
 (call (identifier) @keyword
-      (arguments
-       [(call
-         name: (identifier) @function
-         (arguments
-          [(identifier) @variable.parameter
-           (_ !function !object !name (identifier) @variable.parameter)
-           (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter))
-           (_ !function !object !name (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter)))
-           (_ !function !object !name (_ !function !object !name (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter))))
-           (_ !function !object !name (_ !function !object !name (_ !function !object !name (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter)))))]))
-        (binary_op
-         left:
-         [(call
-           name: (identifier) @function
-           (arguments
-            [(identifier) @variable.parameter
-             (_ !function !object !name (identifier) @variable.parameter)
-             (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter))
-             (_ !function !object !name (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter)))
-             (_ !function !object !name (_ !function !object !name (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter))))
-             (_ !function !object !name (_ !function !object !name (_ !function !object !name (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter)))))]))
-          (identifier) @function]
-         operator: "when")
-        (binary_op
-         left: (identifier) @variable.parameter
-         operator: _ @function
-         right: (identifier) @variable.parameter)])
+      [(call
+        name: (identifier) @function
+        (arguments
+         [(identifier) @variable.parameter
+          (_ !function !object !name (identifier) @variable.parameter)
+          (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter))
+          (_ !function !object !name (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter)))
+          (_ !function !object !name (_ !function !object !name (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter))))
+          (_ !function !object !name (_ !function !object !name (_ !function !object !name (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter)))))]))
+       (binary_op
+        left:
+        [(call
+          name: (identifier) @function
+          (arguments
+           [(identifier) @variable.parameter
+            (_ !function !object !name (identifier) @variable.parameter)
+            (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter))
+            (_ !function !object !name (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter)))
+            (_ !function !object !name (_ !function !object !name (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter))))
+            (_ !function !object !name (_ !function !object !name (_ !function !object !name (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter)))))]))
+         (identifier) @function]
+        operator: "when")
+       (binary_op
+        left: (identifier) @variable.parameter
+        operator: _ @function
+        right: (identifier) @variable.parameter)]
       (#match? @keyword "^(defp|def|defmacrop|defmacro|defguardp|defguard|defdelegate)$")
       (#match? @variable.parameter "^[^_]"))
 
 (call (identifier) @keyword
-      (arguments
-       [(call
-         name: (identifier) @function)
-        (identifier) @function
-        (binary_op
-         left:
-         [(call
-           name: (identifier) @function)
-          (identifier) @function]
-         operator: "when")])
+      [(call
+        name: (identifier) @function)
+       (identifier) @function
+       (binary_op
+        left:
+        [(call
+          name: (identifier) @function)
+         (identifier) @function]
+        operator: "when")]
       (#match? @keyword "^(defp|def|defmacrop|defmacro|defguardp|defguard|defdelegate)$"))
 
 (anonymous_function
@@ -82,11 +80,10 @@
 (unary_op
  operator: "@"
  (call (identifier) @attribute
-       (arguments
-        (heredoc
-         [(heredoc_start)
-          (heredoc_content)
-          (heredoc_end)] @doc)))
+       (heredoc
+        [(heredoc_start)
+         (heredoc_content)
+         (heredoc_end)] @doc))
  (#match? @attribute "^(doc|moduledoc)$"))
 
 (module) @type

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -25,45 +25,47 @@
       (#match? @keyword "^(defmodule|defexception|defp|def|with|case|cond|raise|import|require|use|defmacrop|defmacro|defguardp|defguard|defdelegate|defstruct|alias|defimpl|defprotocol|defoverridable|receive|if|for|try|throw|unless|reraise|super|quote|unquote|unquote_splicing)$"))
 
 (call (identifier) @keyword
-      [(qualified_call
-        name: (identifier) @function
-        (arguments
-         [(identifier) @variable.parameter
-          (_ !function !object !name (identifier) @variable.parameter)
-          (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter))
-          (_ !function !object !name (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter)))
-          (_ !function !object !name (_ !function !object !name (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter))))
-          (_ !function !object !name (_ !function !object !name (_ !function !object !name (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter)))))]))
-       (binary_op
-        left:
-        [(qualified_call
-          name: (identifier) @function
-          (arguments
-           [(identifier) @variable.parameter
-            (_ !function !object !name (identifier) @variable.parameter)
-            (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter))
-            (_ !function !object !name (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter)))
-            (_ !function !object !name (_ !function !object !name (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter))))
-            (_ !function !object !name (_ !function !object !name (_ !function !object !name (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter)))))]))
-         (identifier) @function]
-        operator: "when")
-       (binary_op
-        left: (identifier) @variable.parameter
-        operator: _ @function
-        right: (identifier) @variable.parameter)]
+      (arguments
+       [(call
+         name: (identifier) @function
+         (arguments
+          [(identifier) @variable.parameter
+           (_ !function !object !name (identifier) @variable.parameter)
+           (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter))
+           (_ !function !object !name (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter)))
+           (_ !function !object !name (_ !function !object !name (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter))))
+           (_ !function !object !name (_ !function !object !name (_ !function !object !name (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter)))))]))
+        (binary_op
+         left:
+         [(call
+           name: (identifier) @function
+           (arguments
+            [(identifier) @variable.parameter
+             (_ !function !object !name (identifier) @variable.parameter)
+             (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter))
+             (_ !function !object !name (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter)))
+             (_ !function !object !name (_ !function !object !name (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter))))
+             (_ !function !object !name (_ !function !object !name (_ !function !object !name (_ !function !object !name (_ !function !object !name (identifier) @variable.parameter)))))]))
+          (identifier) @function]
+         operator: "when")
+        (binary_op
+         left: (identifier) @variable.parameter
+         operator: _ @function
+         right: (identifier) @variable.parameter)])
       (#match? @keyword "^(defp|def|defmacrop|defmacro|defguardp|defguard|defdelegate)$")
       (#match? @variable.parameter "^[^_]"))
 
 (call (identifier) @keyword
-      [(qualified_call
-        name: (identifier) @function)
-       (identifier) @function
-       (binary_op
-        left:
-        [(qualified_call
-          name: (identifier) @function)
-         (identifier) @function]
-        operator: "when")]
+      (arguments
+       [(call
+         name: (identifier) @function)
+        (identifier) @function
+        (binary_op
+         left:
+         [(call
+           name: (identifier) @function)
+          (identifier) @function]
+         operator: "when")])
       (#match? @keyword "^(defp|def|defmacrop|defmacro|defguardp|defguard|defdelegate)$"))
 
 (anonymous_function
@@ -80,10 +82,11 @@
 (unary_op
  operator: "@"
  (call (identifier) @attribute
-       (heredoc
-        [(heredoc_start)
-         (heredoc_content)
-         (heredoc_end)] @doc))
+       (arguments
+        (heredoc
+         [(heredoc_start)
+          (heredoc_content)
+          (heredoc_end)] @doc)))
  (#match? @attribute "^(doc|moduledoc)$"))
 
 (module) @type


### PR DESCRIPTION
Currently, we have two different call node types (`call`, `qualified_call`), and we create a different node type based on how call expression is written. Because of this the following `def` expressions produce different AST even though semantically both are the same.

Example:
```elixir
def test(x) do
  x
end

def(test(x), do: x)
```
AST
```lisp
(program [0, 0] - [5, 0]
  (call [0, 0] - [2, 3]   # first call
    name: (identifier [0, 0] - [0, 3])
    (qualified_call [0, 4] - [0, 11]
      name: (identifier [0, 4] - [0, 8])
      (arguments [0, 8] - [0, 11]
        (identifier [0, 9] - [0, 10])))
    (do_block [0, 12] - [2, 3]
      (identifier [1, 2] - [1, 3])))
  (qualified_call [4, 0] - [4, 19]  # second call
    name: (identifier [4, 0] - [4, 3])
    (arguments [4, 3] - [4, 19]
      (qualified_call [4, 4] - [4, 11]
        name: (identifier [4, 4] - [4, 8])
        (arguments [4, 8] - [4, 11]
          (identifier [4, 9] - [4, 10])))
      (keyword_list [4, 13] - [4, 18]
        (keyword [4, 13] - [4, 16]
          (keyword_literal [4, 13] - [4, 16]))
        (identifier [4, 17] - [4, 18])))))
```

Because of this, highlighting does not work for expression `def(test(x), do: x)`. 

Since semantically both are the same, I think it should be represented by the same node type. This also simplify AST. 

AST with proposed changes:
```lisp
(program [0, 0] - [5, 0]
  (call [0, 0] - [2, 3]
    name: (identifier [0, 0] - [0, 3])
    (arguments [0, 4] - [0, 11]
      (call [0, 4] - [0, 11]
        name: (identifier [0, 4] - [0, 8])
        (arguments [0, 8] - [0, 11]
          (identifier [0, 9] - [0, 10]))))
    (do_block [0, 12] - [2, 3]
      (identifier [1, 2] - [1, 3])))
  (call [4, 0] - [4, 19]
    name: (identifier [4, 0] - [4, 3])
    (arguments [4, 3] - [4, 19]
      (call [4, 4] - [4, 11]
        name: (identifier [4, 4] - [4, 8])
        (arguments [4, 8] - [4, 11]
          (identifier [4, 9] - [4, 10])))
      (keyword_list [4, 13] - [4, 18]
        (keyword [4, 13] - [4, 16]
          (keyword_literal [4, 13] - [4, 16]))
        (identifier [4, 17] - [4, 18])))))
```

I'll update tests if this change is okay
