### PR TITLE
WIP: Skip line-break token only in specific context

### DIFF
--- a/test/corpus/case.txt
+++ b/test/corpus/case.txt
@@ -277,3 +277,35 @@ end
                           (string_end))
                         (identifier)))))
                 (identifier)))))))))
+
+================================================================================
+multiple case clause with call conflict
+================================================================================
+
+case s do
+  10 ->
+     :ok
+     foo
+
+  20 ->
+     :ok
+end
+
+--------------------------------------------------------------------------------
+
+(program
+  (call
+    (identifier)
+    (identifier)
+    (do_block
+      (stab_expression
+        (bare_arguments
+          (integer))
+        (atom
+          (atom_literal))
+        (identifier))
+      (stab_expression
+        (bare_arguments
+          (integer))
+        (atom
+          (atom_literal))))))


### PR DESCRIPTION
Skipping line-break token in certain cases is incorrect.

**Example**
```elixir
foo
bar
```
Currently, above expression under in certain cases (depending on context and precedence), can be incorrectly parsed as 
```
(call 
  name: (identifier)
  (identifier))
```
See https://github.com/ananthakumaran/tree-sitter-elixir/issues/5 for exact example

Since we have `\s` as `extras` token, the parser can arbitrarily remove newlines from any place to match rule.

Current changes addresses this, but I'm not 100% confident about the approach. Not sure if there are any corner cases since we still have `\s` as extras.

Fixes #5 