### PR TITLE
only skip newlines before binary ops

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -115,6 +115,7 @@ module.exports = grammar({
 
   externals: $ => [
     $._line_break,
+    $._non_breaking_line,
     $.heredoc_start,
     $.heredoc_content,
     $.heredoc_end,
@@ -148,7 +149,7 @@ module.exports = grammar({
     $._else
   ],
 
-  extras: $ => [$.comment, /\s/, $._escaped_newline],
+  extras: $ => [$.comment, /[\t \f]/, $._non_breaking_line, $._escaped_newline],
 
   conflicts: $ => [
     [$.call],

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -13,6 +13,7 @@ using std::string;
 
 enum TokenType {
   LINE_BREAK,
+  NON_BREAKING_LINE,
 
   HEREDOC_START,
   HEREDOC_CONTENT,
@@ -1337,7 +1338,12 @@ struct Scanner {
       lexer->mark_end(lexer);
       bool reserved;
       if (is_binary_operator_next(lexer, valid_symbols, &reserved)) {
-        return reserved;
+        if (reserved) {
+          return reserved;
+        } else {
+          lexer->result_symbol = NON_BREAKING_LINE;
+          return true;
+        }
       } else {
         lexer->result_symbol = LINE_BREAK;
         return true;

--- a/test/corpus/case.txt
+++ b/test/corpus/case.txt
@@ -277,3 +277,37 @@ end
                           (string_end))
                         (identifier)))))
                 (identifier)))))))))
+
+================================================================================
+case multiline clause
+================================================================================
+
+case 1 do
+  1 ->
+    :ok = :ok
+    foo
+
+  [] ->
+    2
+end
+
+--------------------------------------------------------------------------------
+
+(program
+  (call
+    (identifier)
+    (integer)
+    (do_block
+      (stab_expression
+        (bare_arguments
+          (integer))
+        (binary_op
+          (atom
+            (atom_literal))
+          (atom
+            (atom_literal)))
+        (identifier))
+      (stab_expression
+        (bare_arguments
+          (list))
+        (integer)))))


### PR DESCRIPTION
Instead of allowing the lexer to skip all newlines, only allow it to skip newlines before binary operator

fixes #5