### PR TITLE
don't highlight keyword if it's a function name

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -35,6 +35,10 @@ function binaryOp($, assoc, precedence, operator, bare_keyword) {
   );
 }
 
+function aliases(rules, symbol) {
+  return rules.map(rule => alias(rule, symbol));
+}
+
 function unaryOp($, assoc, precedence, operator) {
   return assoc(
     precedence,
@@ -336,12 +340,10 @@ module.exports = grammar({
             field(
               "function",
               choice(
-                alias($._and, "and"),
-                alias($._or, "or"),
-                alias($._not, "not"),
-                alias($._when, "when"),
-                alias($._in, "in"),
-                ...OPERATORS
+                ...aliases(
+                  [$._and, $._or, $._not, $._when, $._in, ...OPERATORS],
+                  $.function_identifier
+                )
               )
             ),
             optional($.arguments)
@@ -353,22 +355,27 @@ module.exports = grammar({
             field(
               "function",
               choice(
-                alias($.identifier, $.function_identifier),
-                $.true,
-                $.false,
-                $.nil,
-                alias($._when, "when"),
-                alias($._and, "and"),
-                alias($._or, "or"),
-                alias($._not, "not"),
-                alias($._in, "in"),
-                alias($._fn, "fn"),
-                alias($._do, "do"),
-                alias($._end, "end"),
-                alias($._catch, "catch"),
-                alias($._rescue, "rescue"),
-                alias($._after, "after"),
-                alias($._else, "else")
+                ...aliases(
+                  [
+                    $.identifier,
+                    $.true,
+                    $.false,
+                    $.nil,
+                    $._when,
+                    $._and,
+                    $._or,
+                    $._not,
+                    $._in,
+                    $._fn,
+                    $._do,
+                    $._end,
+                    $._catch,
+                    $._rescue,
+                    $._after,
+                    $._else
+                  ],
+                  $.function_identifier
+                )
               )
             ),
             optional($.arguments)

--- a/test/corpus/call.txt
+++ b/test/corpus/call.txt
@@ -97,6 +97,7 @@ Kernel.+(1, 1)
 (program
   (dot_call
     (module)
+    (function_identifier)
     (arguments
       (integer)
       (integer))))
@@ -111,7 +112,8 @@ a.and
 
 (program
   (dot_call
-    (remote_identifier)))
+    (remote_identifier)
+    (function_identifier)))
 
 ================================================================================
 access call followed by dot call
@@ -688,22 +690,26 @@ captured operator call
     (unary_op
       (binary_op
         (dot_call
-          (module))
+          (module)
+          (function_identifier))
         (integer)))
     (unary_op
       (binary_op
         (dot_call
-          (module))
+          (module)
+          (function_identifier))
         (integer)))
     (unary_op
       (binary_op
         (dot_call
-          (module))
+          (module)
+          (function_identifier))
         (integer)))
     (unary_op
       (binary_op
         (dot_call
-          (module))
+          (module)
+          (function_identifier))
         (integer)))))
 
 ================================================================================

--- a/test/highlight/sandbox.ex
+++ b/test/highlight/sandbox.ex
@@ -944,6 +944,21 @@ anon.(1, 2, 3); self; hd([1,2,3])
 #                            ^ punctuation.delimiter
 #                              ^ punctuation.bracket
 #                               ^ punctuation.bracket
+
+a.when.and.or.not.in.fn.do.end.catch.rescue.after.else
+#^ punctuation.delimiter
+#     ^ punctuation.delimiter
+#         ^ punctuation.delimiter
+#            ^ punctuation.delimiter
+#                ^ punctuation.delimiter
+#                   ^ punctuation.delimiter
+#                      ^ punctuation.delimiter
+#                         ^ punctuation.delimiter
+#                             ^ punctuation.delimiter
+#                                   ^ punctuation.delimiter
+#                                          ^ punctuation.delimiter
+#                                                ^ punctuation.delimiter
+
 Kernel.spawn(fn -> :ok end)
 #<- type
 #     ^ punctuation.delimiter


### PR DESCRIPTION
It's valid to have reserved keyword as function name. Don't highlight
these as keyword and treat these as normal function_identifier