### PR TITLE
Remove unused variable in scanner.cc

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -482,10 +482,8 @@ struct Scanner {
       StackItem stack_item;
       stack_item.single_quote = false;
 
-      int32_t quote = '"';
       if (lexer->lookahead == '\'') {
         stack_item.single_quote = true;
-        quote = '\'';
       }
 
       advance(lexer);


### PR DESCRIPTION
This was triggering a compiler warning.